### PR TITLE
Use caret instead of caret-square

### DIFF
--- a/ckanext/facetcollapse/fanstatic/facetcollapse.js
+++ b/ckanext/facetcollapse/fanstatic/facetcollapse.js
@@ -20,16 +20,16 @@ $( document ).ready(function() {
   $(".secondary .filters .collapse:not(.in)").parent().addClass("collapsed");
 
   // add toggle icons
-  $( ".secondary .filters .collapsed .module-heading" ).append( '<i class="toggle-icon fa fa-caret-square-o-right" aria-hidden="true"></i>' );
+  $( ".secondary .filters .collapsed .module-heading" ).append( '<i class="toggle-icon fa fa-caret-right" aria-hidden="true"></i>' );
 
-  $( ".secondary .filters .expanded .module-heading" ).append( '<i class="toggle-icon fa fa-caret-square-o-down" aria-hidden="true"></i>' );
+  $( ".secondary .filters .expanded .module-heading" ).append( '<i class="toggle-icon fa fa-caret-down" aria-hidden="true"></i>' );
 
   // toggle with heading click
   $( ".secondary .filters .module-heading" ).css( 'cursor', 'pointer' );
   $( ".secondary .filters .module-heading" ).click(function() {
     $(this).next().collapse('toggle');
     $(this).parent().toggleClass( "collapsed expanded" );
-    $(this).children(".toggle-icon").toggleClass( "fa-caret-square-o-right fa-caret-square-o-down" );
+    $(this).children(".toggle-icon").toggleClass( "fa-caret-right fa-caret-down" );
   });
 
 });


### PR DESCRIPTION
Hi !

I suggest using ` fa-caret-right` instead of `fa-caret-square-o-right` (and same for down) as they look much lighter, and blend better in CKAN's default theme.

Thanks for the extension !